### PR TITLE
Add `as_list` function

### DIFF
--- a/ABCParse/__init__.py
+++ b/ABCParse/__init__.py
@@ -4,4 +4,4 @@ from ._abc_parse import ABCParse
 from ._function_kwargs import function_kwargs
 from ._as_list import as_list
 
-__version__ = "0.0.7rc0"
+__version__ = "0.0.7rc1"

--- a/ABCParse/_abc_parse.py
+++ b/ABCParse/_abc_parse.py
@@ -5,8 +5,12 @@ __author__ = ", ".join(["Michael E. Vinyard"])
 __email__ = ", ".join(["mvinyard.ai@gmail.com"])
 
 
-# -- import packages: ----------------------------------------------------------
+# -- import packages: ---------------------------------------------------------
 import abc
+
+
+# -- import local dependencies: -----------------------------------------------
+from ._info_message import InfoMessage
 
 
 # -- set typing: ---------------------------------------------------------------
@@ -41,6 +45,7 @@ class ABCParse(abc.ABC):
         dc._PARAMS
         ```
         """
+        
         pass
 
     def __build__(self) -> None:
@@ -106,7 +111,9 @@ class ABCParse(abc.ABC):
         kwargs: Dict,
         public: Optional[List] = [None],
         private: Optional[List] = [],
-        ignore: Optional[List] = []
+        ignore: Optional[List] = [],
+        INFO: str = "INFO",
+        color: str = "BLUE",
     ) -> None:
         """
         Made to be called during `cls.__init__` of the inherited class.
@@ -129,7 +136,12 @@ class ABCParse(abc.ABC):
         for key, val in kwargs.items():
             if not key in self._IGNORE:
                 self.__set__(key, val, public, private)
-
+        
+        self._INFO = InfoMessage(INFO = INFO, color = color)
+        
+    def _update_info_msg(self, **kwargs):
+        self._INFO = self.InfoMessage(**kwargs)
+        
     def __update__(
         self,
         kwargs: Dict,

--- a/ABCParse/_as_list.py
+++ b/ABCParse/_as_list.py
@@ -1,7 +1,6 @@
 
-
 # -- set typing: --------------------------------------------------------------
-from typing import Union, List, Any
+from typing import Any, List, Optional, Union
 
 
 # -- controller class: --------------------------------------------------------
@@ -16,8 +15,14 @@ class AsList(object):
     @property
     def is_list(self) -> bool:
         return isinstance(self._input, List)
+    
+    @property
+    def _MULTIPLE_TARGET_TYPES(self):
+        return isinstance(self._target_type, List)
 
     def _is_target_type(self, value) -> bool:
+        if self._MULTIPLE_TARGET_TYPES:
+            return any([isinstance(value, target_type) for target_type in self._target_type])            
         return isinstance(value, self._target_type)
     
     def _as_list(self) -> List:
@@ -36,7 +41,7 @@ class AsList(object):
     def __call__(
         self,
         input: Union[List[Any], Any],
-        target_type: type = str,
+        target_type: Optional[Union[type, List[type]]] = None,
         *args,
         **kwargs,
     ):
@@ -45,7 +50,7 @@ class AsList(object):
         ----------
         input: Union[List[Any], Any]
 
-        target_type: typel, default = str
+        target_type: Optional[Union[type, List[type]]], default = None
 
         Returns
         -------
@@ -54,15 +59,16 @@ class AsList(object):
         
         self._input = input
         self._target_type = target_type
-
-        assert self.validated_target_types, "Not all values match the target type"
+        
+        if not self._target_type is None:
+            assert self.validated_target_types, "Not all values match the target type"
 
         return self.list_values
 
 
 # -- API-facing function: -----------------------------------------------------
 def as_list(
-    input: Union[List[Any], Any], target_type: type = str, *args, **kwargs,
+    input: Union[List[Any], Any], target_type: Optional[Union[type, List[type]]] = None, *args, **kwargs,
 ):
     """
     Pass input to type-consistent list.
@@ -71,7 +77,7 @@ def as_list(
     ----------
     input: Union[List[Any], Any]
 
-    target_type: typel, default = str
+    target_type: Optional[Union[type, List[type]]], default = None
         If not all values match the target type, an AssertionError is raised.
 
     Returns

--- a/ABCParse/_info_message.py
+++ b/ABCParse/_info_message.py
@@ -1,0 +1,51 @@
+
+# -- import packages: ----------------------------------------------------------
+import licorice_font
+
+
+class InfoMessage:
+    def __init__(
+        self, silent: bool = False, INFO: str = "INFO", color: str = "BLUE"
+    ) -> None:
+
+        """
+
+        Parameters:
+        -----------
+        silent
+            type: bool
+            default: False
+
+        INFO
+            type: str
+            default: "INFO"
+
+        color
+            type: str
+            default: "BLUE"
+
+        Returns:
+        --------
+        None
+        """
+
+        self.INFO = licorice_font.font_format(INFO, [color])
+        self._SILENT = silent
+
+    def _format_msg_title(self, INFO) -> str:
+        return f" - [{INFO}] | "
+
+    def __call__(self, msg: str) -> None:
+
+        """
+        Prints message according to above-specified formatting.
+
+        Parameters:
+        -----------
+        msg
+            type: str
+        """
+
+        if not self._SILENT:
+            self.BASE = self._format_msg_title(self.INFO)
+            print(self.BASE + msg)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setuptools.setup(
     name="ABCParse",
-    version="0.0.7rc0",
+    version="0.0.7rc1",
     python_requires=">3.9.0",
     author="Michael E. Vinyard",
     author_email="mvinyard.ai@gmail.com",


### PR DESCRIPTION
Helpful for passing varying length / type objects that you may wish (intuitively) to be a list or sometimes, not a list. Prevents errors, and makes it (hopefully) such that the user does not have to think as much.